### PR TITLE
Generate table of contents in 2 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@
 
   Songbook is an easy to use tool for creating songbooks where each song is represented by a different file, allowing them to be easily shared or moved between different songbooks. It has it's own display module or it can generate LaTeX files and compile them to pdf.
 
+  ## Usage
+
+  ```
+  python3 songbook.pdf
+  ```
+
   ## Configuration
+
+  The configuration can be altered by modifying the `config.json` file.
 
   ### pdfSettings
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   ## Usage
 
   ```
-  python3 songbook.pdf
+  python3 songbook.py
   ```
 
   ## Configuration

--- a/data/latexheader.txt
+++ b/data/latexheader.txt
@@ -8,6 +8,7 @@
 \usepackage{changepage}
 \usepackage{graphicx}
 \usepackage{hyperref}
+\usepackage{multicol}
 
 \hypersetup{
     hidelinks,
@@ -52,4 +53,4 @@ Dziękujemy!}
 \renewcommand{\rmdefault}{ptm}
 \renewcommand{\ttdefault}{zi4}
 
-\renewcommand{\contentsname}{Spis treści}
+\renewcommand{\contentsname}{\vspace*{-104pt}}

--- a/src/headerconfig.py
+++ b/src/headerconfig.py
@@ -15,7 +15,7 @@ def packages(packs):
     return string
 
 def getPackageList():
-    return [("fontenc", "T1"), ("babel", "english"), "blindtext", "paracol", "geometry", "indentfirst", "changepage", "graphicx", "hyperref"]
+    return [("fontenc", "T1"), ("babel", "english"), "blindtext", "paracol", "geometry", "indentfirst", "changepage", "graphicx", "hyperref", "multicol"]
 
 def hyperSetup():
     return "\\hypersetup{\n    hidelinks,\n    linktoc=all\n}\n\n"
@@ -37,7 +37,8 @@ def font():
     return f"\\renewcommand{{\\rmdefault}}{{{config.lyricsFont}}}\n\\renewcommand{{\\ttdefault}}{{{config.chordsFont}}}\n\n"
 
 def toc():
-    return "\\renewcommand{\\contentsname}{Spis treści}\n"
+    # hack avoiding insertion of the toc header, which doesn't play well with 2 columns
+    return "\\renewcommand{\\contentsname}{\\vspace*{-104pt}}\n"
 
 def titleSettings():
     onePercentHack = "\\vspace{0.40\\textheight} 1 \% podatku dla “Hawiarskiej Koliby”\\\\\n" + \

--- a/src/songbookTeXmaker.py
+++ b/src/songbookTeXmaker.py
@@ -194,7 +194,7 @@ async def _asyncMain():
         for titleSong in titleSongs:
             songCount += await processSingleSong(songbookDict[titleSong[0]].songs[titleSong[1]], songbookFile)
         
-        await songbookFile.write(enUTF8("\\tableofcontents\n"))
+        await songbookFile.write(enUTF8("\n\t\\chapter*{Spis treści}\n\\begin{multicols}{2}\n\\tableofcontents\n\\end{multicols}\n"))
 
         for cat in cats.keys():
             if cat != "Title":
@@ -202,7 +202,7 @@ async def _asyncMain():
                 await songbookFile.write(enUTF8(songbookDict[cat].tex))
                 songCount += await processCategory(songbookDict[cat], songbookFile, titleSongs)
 
-        await songbookFile.write(enUTF8(f"\\IfFileExists{{{config.outputFile}_list.toc}}{{\n\t\\chapter*{{Spis treści}}\n\t\\input{{{config.outputFile}_list.toc}}\n}}{{}}\n"))
+        await songbookFile.write(enUTF8(f"\\IfFileExists{{{config.outputFile}_list.toc}}{{\n\t\\chapter*{{Spis treści}}\n\\begin{{multicols}}{{2}}\n\t\\input{{{config.outputFile}_list.toc}}\n\\end{{multicols}}\n}}{{}}\n"))
         await songbookFile.write(enUTF8("\\end{document}"))
     print(f"Total number of songs: {songCount}")
     return texOutFile


### PR DESCRIPTION
Currently, looking at the table of contents makes it hard to match the song name to the page where it can be found, especially if a user is drunk. The reason for the problem is an enormous amount of dots between song titles and page numbers. The solution proposed here is to format the TOC in 2 columns, which has additional benefits:
- it was easy to implement using latex's default TOC
- it reduces reverting pages when looking at the TOC
- it reduces the size of the songbook

Check the `songbook.pdf` file to see how it looks like