### PR TITLE
added config.json reload before creating pdf

### DIFF
--- a/src/obj/Config.py
+++ b/src/obj/Config.py
@@ -57,6 +57,9 @@ class Configuration:
         except KeyError:
             self.devSettings = defaultdict(lambda: False)
 
+    def update(self):
+        self.__init__("config.json")
+
 
 config = Configuration("config.json")
 

--- a/src/songbookTeXmaker.py
+++ b/src/songbookTeXmaker.py
@@ -219,6 +219,7 @@ def main():
 
 
 async def _asyncMain():
+    config.update()
     headerconfig.main()
 
     texOutFile = f"{config.outputFile}.tex"


### PR DESCRIPTION
Currently once user makes any changes to `config.json` they are ignored and PDF is created with old settings. To make changes available app needs to be restarted. 
With these changes config is reloaded before PDF creation regardless of app restart. 