### PR TITLE
feat(sidebar): enable sidebar hide while using mid-sized screen (eg. tablets)

### DIFF
--- a/songbook/src/flask/static/style.css
+++ b/songbook/src/flask/static/style.css
@@ -21,7 +21,57 @@
 }
 
 .nav-side-menu .toggle-btn {
+  display: block;
+}
+
+/* Floating button to reopen the sidebar when it is hidden.
+   Visual style is provided by Bootstrap's .btn .btn-secondary in the markup. */
+.open-sidebar-btn {
   display: none;
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 1000;
+  font-size: 18px;
+  line-height: 1;
+}
+.sidebar-hidden .open-sidebar-btn {
+  display: block !important;
+}
+
+/* When the floating button is showing, push the main content's first
+   heading over so the button doesn't cover the song title.
+   Only applies on tablets/desktop -- on mobile the sidebar is always
+   visible and the floating button is hidden. */
+@media (min-width: 768px) {
+  .sidebar-hidden .main h1,
+  .sidebar-hidden .main h2,
+  .sidebar-hidden .main .h1,
+  .sidebar-hidden .main .h2 {
+    padding-left: 56px;
+  }
+}
+
+/* Sidebar hidden state -- slide off-canvas on tablets/desktop */
+.nav-side-menu {
+  transition: transform 0.3s ease;
+}
+@media (min-width: 768px) {
+  .sidebar-hidden .nav-side-menu {
+    transform: translateX(-100%);
+  }
+  .sidebar-hidden .main {
+    padding-left: 0 !important;
+  }
+}
+/* On mobile the nav pane is always visible; the in-brand hamburger only
+   toggles the menu list, so the sidebar-hidden state has no effect here
+   and the floating reopen button is not needed. */
+@media (max-width: 767px) {
+  .open-sidebar-btn,
+  .sidebar-hidden .open-sidebar-btn {
+    display: none !important;
+  }
 }
 
 .nav-side-menu .btn {
@@ -34,6 +84,21 @@
   margin-top: 4px;
   margin-right: 15px;
   float: right;
+}
+
+.brand .toggle-btn {
+  display: inline-block;
+  float: left;
+  margin-right: 0;
+  margin-left: 15px;
+}
+
+@media (max-width: 767px) {
+  .brand .toggle-btn {
+    float: right;
+    margin-right: 15px;
+    margin-left: 0;
+  }
 }
 
 .nav-side-menu .song {
@@ -137,9 +202,6 @@
     position: relative;
     width: 100%;
     margin-bottom: 10px;
-  }
-  .nav-side-menu .toggle-btn {
-    display: block;
   }
 
   .nav-side-menu .btn {

--- a/songbook/src/flask/templates/app.js
+++ b/songbook/src/flask/templates/app.js
@@ -1134,5 +1134,21 @@ function toggleDarkMode(save){
 }
 
 function collapse() {
-	$("#menu-content").collapse('toggle');
-  }
+	// On mobile the navpanel is always visible, so toggle songlist  rather than hide the panel
+	if (window.matchMedia && window.matchMedia("(max-width: 767px)").matches) {
+		var menu = document.getElementById("menu-content");
+		if (menu) {
+			menu.classList.toggle("show");
+		}
+		return;
+	}
+	var isHidden = document.documentElement.classList.toggle("sidebar-hidden");
+	document.body.classList.toggle("sidebar-hidden", isHidden);
+	try {
+		if (isHidden) {
+			sessionStorage.setItem("sidebarHidden", "1");
+		} else {
+			sessionStorage.removeItem("sidebarHidden");
+		}
+	} catch (e) { /* sessionStorage unavailable */ }
+}

--- a/songbook/src/flask/templates/page.html
+++ b/songbook/src/flask/templates/page.html
@@ -39,9 +39,11 @@
 </head>
 
 <body>
+        <button class="open-sidebar-btn btn btn-secondary" onclick="collapse()" aria-label="Show menu" title="Show menu"><i class="fa fa-bars"></i></button>
         <div class="p-2 nav-side-menu">
-            <div class="brand">Śpiewnik HK
+            <div class="brand">
                 <button onclick="collapse()" class="toggle-btn"><i class="fa fa-bars fa-2x btn"></i></button>
+                Śpiewnik HK
                 <button onclick="toggleDarkMode(true)"><i class="fa fa-moon-o fa-2x btn"></i></button>
             </div>
             <div class="menu-list">


### PR DESCRIPTION
Added option to toggle nav pane when on side of the screen to enable full screen song view on mid-sized screen regardless of screen orientation. 
<img width="1260" height="376" alt="image" src="https://github.com/user-attachments/assets/77feeee6-05cf-4beb-a531-778edf4c47c8" />
